### PR TITLE
Fix command name issue

### DIFF
--- a/hata/__init__.py
+++ b/hata/__init__.py
@@ -1,5 +1,5 @@
 ﻿# -*- coding: utf-8 -*-
-__version__ = '20191221.1'
+__version__ = '20191222.1'
 
 import sys
 ASYNC_ONLY = ('async_only' in sys.argv) or ('async-only' in sys.argv)

--- a/hata/events.py
+++ b/hata/events.py
@@ -731,9 +731,10 @@ class Cooldown(object):
             limit=int(limit)
         self.limit=limit-weight
         
+        if (case is not None) and (not case.islower()):
+            case=case.lower()
+        
         if func is None:
-            if case is None:
-                case=''
             self.__name__=case
             self.__func__=EventDescriptor.DEFAULT_EVENT
             return self._wrapper
@@ -769,9 +770,10 @@ class Cooldown(object):
         self.limit  = source.limit+source.weight-weight
         self.handler= source.handler
         
+        if (case is not None) and (not case.islower()):
+            case=case.lower()
+            
         if func is None:
-            if case is None:
-                case=''
             self.__name__=case
             self.__func__=EventDescriptor.DEFAULT_EVENT
             return self._wrapper

--- a/hata/events_compiler.py
+++ b/hata/events_compiler.py
@@ -1134,9 +1134,10 @@ class ContentParser(object):
         self._on_failure=on_failure
         self._is_method=is_method
 
+        if (case is not None) and (not case.islower()):
+            case=case.lower()
+        
         if func is None:
-            if case is None:
-                case=''
             self.__name__=case
             self.__func__=EventDescriptor.DEFAULT_EVENT
             return self._wrapper

--- a/hata/parsers.py
+++ b/hata/parsers.py
@@ -2497,12 +2497,19 @@ class _EventCreationManager(object):
         
         if case is None:
             case=check_name(func,None)
+
+        if (not case.islower()):
+            case=case.lower()
+        
         func=self.parent.__setevent__(func,case)
         return func
     
     def remove(self,func,case=None):
         if case is None:
             case=check_name(func,None)
+        
+        if (not case.islower()):
+            case=case.lower()
         
         self.parent.__delevent__(func,case)
     
@@ -2561,7 +2568,7 @@ class eventlist(list,metaclass=removemeta):
         '__setitem__','__contains__')
     __slots__=()
     def __init__(self,iterable=None):
-        if iterable is not None and iterable:
+        if (iterable is not None) and iterable:
             self.extend(iterable)
 
     class _wrapper(object):
@@ -2611,14 +2618,21 @@ class eventlist(list,metaclass=removemeta):
             raise ValueError('\n'.join(collected))
     
     def __call__(self,func=None,case=None):
+        if (case is not None) and (not case.islower()):
+            case=case.lower()
+        
         if func is None:
             return self._wrapper(self,case)
         
         func=just_convert(func)
+        
         list.append(self,(func,case))
         return func
     
     def remove(self,func,case=None):
+        if (case is not None) and (not case.islower()):
+            case=case.lower()
+            
         # we might overwrite __iter__ later
         for converted_func,converted_case in list.__iter__(self):
             
@@ -2823,6 +2837,10 @@ class EventDescriptor(object):
                 raise ValueError('\'name\' can not be None if \'pass_to_event\' is set to True')
             if case is None:
                 case=check_name(func,None)
+            
+            if (not case.islower()):
+                case=case.lower()
+            
             event_handler=getattr(self,name)
             func=event_handler.__setevent__(func,case)
             return func

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,19 @@
+import os, re
+from ast import literal_eval
 from setuptools import setup
+
+version_search_pattern=re.compile('^__version__[ ]*=[ ]*((?:\'[^\']+\')|(?:\"[^\"]+\"))[ ]*$',re.M)
+with open(os.path.join(os.path.split(__file__)[0],'hata','__init__.py')) as file:
+    parsed=version_search_pattern.search(file.read())
+
+if parsed is None:
+    raise RuntimeError('No version found at __init__.py')
+
+version=literal_eval(parsed.group(1))
 
 setup(
     name        = 'hata',
-    version     = '20191221.1',
+    version     = version,
     packages    = [
         'hata',
         'hata.bin',


### PR DESCRIPTION
Fix issue found by Proxy : Commands added through `case=`, were not recognized, if they contained not only lower case characters.

Make setup.py autodetect version.