### PR TITLE
Separate emoji events and others

### DIFF
--- a/docs/ref/ChannelCategory.md
+++ b/docs/ref/ChannelCategory.md
@@ -170,16 +170,13 @@ initializers.
 - items : (`str`, `Any`)
 
 Updates the channel and returns it's old attributes as (attribute name,
-old value). Exception at the returned data is only
-[`.overwrites`](#overwrites), because it is calculated with
-[`listdifference`](listdifference.md) and the data contains the
-function's return instead of the actual old value.
+old value).
 
-| name              | description                                                           |
-|-------------------|-----------------------------------------------------------------------|
-| name              | str                                                                   |
-| overwrites        | [listdifference](listdifference.md) return of [PermOW](PermOW.md)     |
-| position          | int                                                                   |
+| name          | description                   |
+|---------------|-------------------------------|
+| name          | str                           |
+| overwrites    | list of [PermOW](PermOW.md)   |
+| position      | int                           |
 
 ### `_update_no_return(self,data)` (method)
 

--- a/docs/ref/ChannelGroup.md
+++ b/docs/ref/ChannelGroup.md
@@ -245,12 +245,12 @@ initializers.
 Updates the channel and returns it's old attributes as (attribute name,
 old value).
 
-| name              | description                                                                               |
-|-------------------|-------------------------------------------------------------------------------------------|
-| icon              | int                                                                                       |
-| name              | str                                                                                       |
-| owner             | [`User`](User.md) / [`Client`](Client.md)                                                 |
-| users             | [listdifference](listdifference.md) return of [`User`](User.md) / [`Client`](Client.md)   |
+| name              | description                                       |
+|-------------------|---------------------------------------------------|
+| icon              | int                                               |
+| name              | str                                               |
+| owner             | [`User`](User.md) / [`Client`](Client.md)         |
+| users             | list of [`User`](User.md) / [`Client`](Client.md) |
 
 ### `_update_no_return(self,data)` (method)
 

--- a/docs/ref/ChannelStore.md
+++ b/docs/ref/ChannelStore.md
@@ -185,18 +185,15 @@ initializers.
 - items : (`str`, `Any`)
 
 Updates the channel and returns it's old attributes as (attribute name,
-old value). Exception at the returned data is only
-[`.overwrites`](#overwrites), because it is calculated with
-[`listdifference`](listdifference.md) and the data contains the
-function's return instead of the actual old value.
+old value).
 
-| name              | description                                                           |
-|-------------------|-----------------------------------------------------------------------|
-| category          | [ChannelCategory](ChannelCategory.md) / [Guild](Guild.md)             |
-| name              | str                                                                   |
-| nsfw              | bool                                                                  |
-| overwrites        | [listdifference](listdifference.md) return of [PermOW](PermOW.md)     |
-| position          | int                                                                   |
+| name              | description                                               |
+|-------------------|-----------------------------------------------------------|
+| category          | [ChannelCategory](ChannelCategory.md) / [Guild](Guild.md) |
+| name              | str                                                       |
+| nsfw              | bool                                                      |
+| overwrites        | list of [PermOW](PermOW.md)                               |
+| position          | int                                                       |
 
 ### `_update_no_return(self,data)` (method)
 

--- a/docs/ref/ChannelText.md
+++ b/docs/ref/ChannelText.md
@@ -261,21 +261,18 @@ initializers.
 - items : (`str`, `Any`)
 
 Updates the channel and returns it's old attributes as (attribute name,
-old value). Exception at the returned data is only
-[`.overwrites`](#overwrites), because it is calculated with
-[`listdifference`](listdifference.md) and the data contains the
-function's return instead of the actual old value.
+old value).
 
-| name              | description                                                           |
-|-------------------|-----------------------------------------------------------------------|
-| category          | [ChannelCategory](ChannelCategory.md) / [Guild](Guild.md)           |
-| name              | str                                                                   |
-| nsfw              | bool                                                                  |
-| overwrites        | [listdifference](listdifference.md) return of [PermOW](PermOW.md)   |
-| position          | int                                                                   |
-| slowmode          | int                                                                   |
-| topic             | str                                                                   |
-| type              | int                                                                   |
+| name              | description                                               |
+|-------------------|-----------------------------------------------------------|
+| category          | [ChannelCategory](ChannelCategory.md) / [Guild](Guild.md) |
+| name              | str                                                       |
+| nsfw              | bool                                                      |
+| overwrites        | list of [PermOW](PermOW.md)                               |
+| position          | int                                                       |
+| slowmode          | int                                                       |
+| topic             | str                                                       |
+| type              | int                                                       |
 
 ### `_update_no_return(self,data)` (method)
 

--- a/docs/ref/ChannelVoice.md
+++ b/docs/ref/ChannelVoice.md
@@ -198,19 +198,16 @@ initializers.
 - items : (`str`, `Any`)
 
 Updates the channel and returns it's old attributes as (attribute name,
-old value). Exception at the returned data is only
-[`.overwrites`](#overwrites), because it is calculated with
-[`listdifference`](listdifference.md) and the data contains the
-function's return instead of the actual old value.
+old value).
 
-| name              | description                                                           |
-|-------------------|-----------------------------------------------------------------------|
-| bitrate           | int                                                                   |
-| category          | [ChannelCategory](ChannelCategory.md) / [Guild](Guild.md)             |
-| name              | str                                                                   |
-| overwrites        | [listdifference](listdifference.md) return of [PermOW](PermOW.md)     |
-| position          | int                                                                   |
-| user_limit        | int                                                                   |
+| name              | description                                               |
+|-------------------|-----------------------------------------------------------|
+| bitrate           | int                                                       |
+| category          | [ChannelCategory](ChannelCategory.md) / [Guild](Guild.md) |
+| name              | str                                                       |
+| overwrites        | list of [PermOW](PermOW.md)                               |
+| position          | int                                                       |
+| user_limit        | int                                                       |
 
 ### `_update_no_return(self,data)` (method)
 

--- a/docs/ref/Client.md
+++ b/docs/ref/Client.md
@@ -936,7 +936,7 @@ additional `reason` argument can be passed too, which should show up the
 Similar to `message_delete_multiple`, but it accepts messages from different
 channels.
 
-### `message_delete_sequence(self,channel,after=None,before=None,limit=None,reason=None):
+### `message_delete_sequence(self,channel,after=None,before=None,limit=None,reason=None)`
 
 - `awaitable`
 - returns : `None`

--- a/docs/ref/Client.md
+++ b/docs/ref/Client.md
@@ -1695,9 +1695,10 @@ Deletes the [`emoji`](Emoji.md). The `reason` shows up at the emoji's
 
 Edits the [`emoji`](Emoji.md) with the given arguments:
 
-- `name`, default : `None`. If set changes the emoji's name
-- `roles`, default : `[]`. The [roles](Role.md), which with the people can use
-the emoji.
+- `name`, default : `None`. If set changes the emoji's name. Emoji name length
+can be between 2 and 32.
+- `roles`, default : `None`. A list of [roles](Role.md), with which the users
+can use the emoji.
 - `reason`, default : `None`. Shows up at the [guild](Guild.md)'s audit logs.
 
 ### `vanity_invite(self,guild)`

--- a/docs/ref/Emoji.md
+++ b/docs/ref/Emoji.md
@@ -76,14 +76,14 @@ set to False.
 
 ### `roles`
 
-- type : `list` / `NoneType`
+- type : `set` / `NoneType`
 - default : `None`
 - elements : [`Role`](Role.md)
 
-The list of roles for which the custom emoji is whitelisted to.  If the emoji
-is not limited for specific roles, then it just uses it's guild's `.roles`
-attribute. If the emoji is a builtin (unicode) emoji, then this attribute is
-set to `None`.
+The set of roles for which the custom emoji is whitelisted to.  If the emoji
+is not limited for specific roles, then this value is set to `None`. If the
+emoji is a builtin (unicode) emoji, then this attribute is set to `None` as 
+well.
 
 ### `unicode`
 
@@ -98,7 +98,7 @@ of unicode emojis this attribute stores the emoji's unicode representation.
 - type : [`User`](User.md) / [`Client`](Client.md)
 - default : [`ZEROUSER`](ZEROUSER.md)
 
-The creator of the custom emoji. The emoji must be requested from the discord
+The creator of the custom emoji. The emoji must be requested from the Discord
 API, or it's user will be just the default `ZEROUSER`.
 
 ## `Properties`
@@ -107,7 +107,7 @@ API, or it's user will be just the default `ZEROUSER`.
 
 - returns : `str`
 
-This property returns the emoji's form, when it is sent in a mesage.
+This property returns the emoji's form, when it is sent in a [msesage](Message.md).
 
 ### `as_reaction`
 
@@ -245,6 +245,16 @@ Updates the emoji by the given data.
 
 Updates the emoji and returns it's old attributes with
 (`attribute name`, `old value`) items.
+
+| name              | description                   |
+|-------------------|-------------------------------|
+| animated          | bool                          |
+| available         | bool                          |
+| managed           | bool                          |
+| name              | str                           |
+| require_colons    | bool                          |
+| roles             | set of [Role](Role.md) / None |
+
 
 ### `_delete(self)` (method)
 

--- a/docs/ref/Emoji.md
+++ b/docs/ref/Emoji.md
@@ -107,7 +107,7 @@ API, or it's user will be just the default `ZEROUSER`.
 
 - returns : `str`
 
-This property returns the emoji's form, when it is sent in a [msesage](Message.md).
+This property returns the emoji's form, when it is sent in a [message](Message.md).
 
 ### `as_reaction`
 

--- a/docs/ref/EventDescriptor.md
+++ b/docs/ref/EventDescriptor.md
@@ -144,21 +144,21 @@ Called when a [channel](CHANNEL_TYPES.md) is deleted.
 Called when a channel](CHANNEL_TYPES.md) is edited. The `old` argument is a `dict`
 of the changed attributes, what contains (`attribute name`, `old value`) items.
 
-| name                      | description                                                                           |
-|---------------------------|---------------------------------------------------------------------------------------|
-| bitrate                   | int                                                                                   |
-| category                  | [Guild](Guild.md) / [ChannelCategory](ChannelCategory.md)                             |
-| icon                      | int                                                                                   |
-| name                      | str                                                                                   |
-| nsfw                      | bool                                                                                  |
-| overwrites                | [listdifference](listdifference.md) return of [PermOW](PermOW.md)                     |
-| owner                     | [User](User.md) / [Client](Client.md)                                                 |
-| position                  | int                                                                                   |
-| slowmode                  | int                                                                                   |
-| topic                     | str                                                                                   |
-| type                      | int                                                                                   |
-| user_limit                | int                                                                                   |
-| users                     | [listdifference](listdifference.md) return  of [User](User.md) / [Client](Client.md)  |
+| name                      | description                                               |
+|---------------------------|-----------------------------------------------------------|
+| bitrate                   | int                                                       |
+| category                  | [Guild](Guild.md) / [ChannelCategory](ChannelCategory.md) |
+| icon                      | int                                                       |
+| name                      | str                                                       |
+| nsfw                      | bool                                                      |
+| overwrites                | list of [PermOW](PermOW.md)                               |
+| owner                     | [User](User.md) / [Client](Client.md)                     |
+| position                  | int                                                       |
+| slowmode                  | int                                                       |
+| topic                     | str                                                       |
+| type                      | int                                                       |
+| user_limit                | int                                                       |
+| users                     | list of [User](User.md) / [Client](Client.md)             |
 
 ### `channel_group_user_add(client,channel,user)`
 
@@ -247,30 +247,30 @@ suppressed, but instead of desuppressing and updating, it removes the old embeds
 and adds new one to it. The message's flag will still show that the it's embeds
 are suppressed.
 
-### `emoji_edit(client,guild,changes)`
+### `emoji_create(client,guild,emoji)`
 
-Called when an [emoji](Emoji.md) is edited at a [guild](Guild.md). Not like at the
-case of most `edit` events, discord sends an `emoji` event for a guild as
-whole. So we have one `emoji` event instead of 3 separate.
+Called, when an [emoji](Emoji.md) is created at a [guild](Guild.md).
 
-(Or should we separate them?)
+### `emoji_delete(client,guild,emoji)`
 
-The `changes` arguemnt is list of `(operation, emoji, old)` tuples. Where:
-- Operation can be `n` for a `new`, `e` for `edit` and `d` for delete.
-- Emoji is every time the updated emoji.
-- Old is `None` or at the case of `edit` it is the `dict` of the old attributes.
+Called, when an [emoji](Emoji.md) is deleted at a [guild](Guild.md).
 
-The (`attribute name`, `old value`) items of `old`:
+> Deleted emojis's [`.guild`](Emoji.md#guild) attribute is set to `None`.
 
-| name                      | description               |
-|---------------------------|---------------------------|
-| animated                  | bool                      |
-| available                 | bool                      |
-| managed                   | bool                      |
-| name                      | str                       |
-| require_colons            | bool                      |
-| roles                     | list of [Role](Role.md)   |
+### `emoji_edit(client,guild,emoji,old)`
 
+Called when an [emoji](Emoji.md) is edited at a [guild](Guild.md).  The `old`
+argument is a `dict` of the changed attributes, what contains (`attribute name`,
+`old value`) items.
+
+| name                      | description                   |
+|---------------------------|-------------------------------|
+| animated                  | bool                          |
+| available                 | bool                          |
+| managed                   | bool                          |
+| name                      | str                           |
+| require_colons            | bool                          |
+| roles                     | set of [Role](Role.md) / None |
 
 Additionally if an [emoji](Emoji.md) is upated it's `.user` instance attribute
 might be set too.
@@ -315,36 +315,36 @@ left (got kicked or banned too) from it. The `profile` is the
 Called when a [guild](Guild.md) is edited. The `old` argument is a `dict`
 of the changed attributes, what contains (`attribute name`, `old value`) items.
 
-| name                      | description                                                                       |
-|---------------------------|-----------------------------------------------------------------------------------|
-| afk_channel               | [ChannelVoice](ChannelVoice.md) / None                                            |
-| afk_timeout               | int                                                                               |
-| available                 | bool                                                                              |
-| banner                    | int                                                                               |
-| booster_count             | int                                                                               |
-| content_filter            | [ContentFilterLevel](ContentFilterLevel.md)                                       |
-| description               | str                                                                               |
-| embed_channel             | [ChannelText](ChannelText.md) / None                                              |
-| embed_enabled             | bool                                                                              |
-| features                  | [listdifference](listdifference.md) return of [GuildFeature](GuildFeature.md)     |
-| has_animated_icon         | bool                                                                              |
-| icon                      | int                                                                               |
-| max_presences             | int                                                                               |
-| max_users                 | int                                                                               |
-| message_notification      | [MessageNotificationLevel](MessageNotificationLevel.md)                           |
-| mfa                       | [MFA](MFA.md)                                                                     |
-| name                      | str                                                                               |
-| owner                     | [User](User.md) / [Client](Client.md)                                             |
-| preferred_locale          | str                                                                               |
-| premium_tier              | int                                                                               |
-| region                    | [VoiceRegion](VoiceRegion.md)                                                     |
-| splash                    | int                                                                               |
-| system_channel            | [ChannelText](ChannelText.md) / None                                              |
-| system_channel_flags      | [SystemChannelFlag](SystemChannelFlag.md)                                         |
-| vanity_code               | str                                                                               |
-| verification_level        | [VerificationLevel](VerificationLevel.md)                                         |
-| widget_channel            | [ChannelText](ChannelText.md) / None                                              |
-| widget_enabled            | bool                                                                              |
+| name                      | description                                               |
+|---------------------------|-----------------------------------------------------------|
+| afk_channel               | [ChannelVoice](ChannelVoice.md) / None                    |
+| afk_timeout               | int                                                       |
+| available                 | bool                                                      |
+| banner                    | int                                                       |
+| booster_count             | int                                                       |
+| content_filter            | [ContentFilterLevel](ContentFilterLevel.md)               |
+| description               | str                                                       |
+| embed_channel             | [ChannelText](ChannelText.md) / None                      |
+| embed_enabled             | bool                                                      |
+| features                  | list of [GuildFeature](GuildFeature.md)                   |
+| has_animated_icon         | bool                                                      |
+| icon                      | int                                                       |
+| max_presences             | int                                                       |
+| max_users                 | int                                                       |
+| message_notification      | [MessageNotificationLevel](MessageNotificationLevel.md)   |
+| mfa                       | [MFA](MFA.md)                                             |
+| name                      | str                                                       |
+| owner                     | [User](User.md) / [Client](Client.md)                     |
+| preferred_locale          | str                                                       |
+| premium_tier              | int                                                       |
+| region                    | [VoiceRegion](VoiceRegion.md)                             |
+| splash                    | int                                                       |
+| system_channel            | [ChannelText](ChannelText.md) / None                      |
+| system_channel_flags      | [SystemChannelFlag](SystemChannelFlag.md)                 |
+| vanity_code               | str                                                       |
+| verification_level        | [VerificationLevel](VerificationLevel.md)                 |
+| widget_channel            | [ChannelText](ChannelText.md) / None                      |
+| widget_enabled            | bool                                                      |
 
 ### `guild_sync(client,guild)`
 
@@ -393,24 +393,22 @@ message's id-s, independently if they are loaded or not.
 
 Called when a loaded [message](Message.md) is edited. The `old` argument is a
 `dict` of the changed attributes, what contains (`attribute name`, `old value`)
-items.
+items. A special case is if a message is (un)pinned or (un)suppressed , because
+then the `old` is not going to contain `'edited'`, only `'pinned'` or `flags`.
 
-| name                      | description                                                                                                                                                                                                                       |
-|---------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| activity                  | [MessageActivity](MessageActivity.md)                                                                                                                                                                                             |
-| activity_party_id         | str                                                                                                                                                                                                                               |
-| application               | [MessageApplication](MessageApplication.md) / None                                                                                                                                                                                |
-| content                   | str                                                                                                                                                                                                                               |
-| cross_mentions            | None / (list of [Channel](CHANNEL_TYPES.md) / [UnknownCrossMention](UnknownCrossMention.md)) / ([listdifference](listdifference.md) return of [Channel](CHANNEL_TYPES.md) / [UnknownCrossMention](UnknownCrossMention.md)         |                                            |
-| edited                    | None / `datetime`                                                                                                                                                                                                                 |
-| embeds                    | list of [EmbedCore](EmbedCore.md)                                                                                                                                                                                                 |
-| flags                     | [MessageFlag](MessageFlag.md)                                                                                                                                                                                                     |
-| mention_everyone          | bool                                                                                                                                                                                                                              |
-| pinned                    | bool                                                                                                                                                                                                                              |
-| user_mentions             | None / (list of [User](User.md)) / [lient](Client.md)) / ([listdifference](listdifference.md) return of [User](User.md) / [Client](Client.md))                                                                                    |
-| role_mentions             | None / (list of [Role](Role.md)) / ([listdifference](listdifference.md) return of [Role](Role.md)))                                                                                                                               |
-
-`old` might not contain `edited` if only `pinned` or `flags` is updated.
+| name                      | description                                                                                   |
+|---------------------------|-----------------------------------------------------------------------------------------------|
+| activity                  | Nne / [MessageActivity](MessageActivity.md)                                                   |
+| application               | None /[MessageApplication](MessageApplication.md)                                             |
+| content                   | str                                                                                           |
+| cross_mentions            | None / (list of [Channel](CHANNEL_TYPES.md) / [UnknownCrossMention](UnknownCrossMention.md))  |
+| edited                    | None / datetime                                                                               |
+| embeds                    | list of [EmbedCore](EmbedCore.md)                                                             |
+| flags                     | [MessageFlag](MessageFlag.md)                                                                 |
+| mention_everyone          | bool                                                                                          |
+| pinned                    | bool                                                                                          |
+| user_mentions             | None / (list of [User](User.md)) / [lient](Client.md))                                        |
+| role_mentions             | None / (list of [Role](Role.md))                                                              |
 
 ### `reaction_add(client,message,emoji,user)`
 
@@ -545,15 +543,15 @@ what contains (`attribute name`, `old value`) items.
 Not like at other cases, this event updates not only
 [GuildProfile](GuildProfile.md) attributes.
 
-| name                      | description                                                   |
-|---------------------------|---------------------------------------------------------------|
-| nick                      | str / None                                                    |
-| roles                     | [listdifference](listdifference.md) return of [Role](Role.md) |
-| boosts_since              | datetime / None                                               |
+| name                      | description               |
+|---------------------------|---------------------------|
+| nick                      | str / None                |
+| roles                     | list of [Role](Role.md)   |
+| boosts_since              | datetime / None           |
 
 ### `voice_state_update(client,state,action,old)`
 
-Called when a [voice state](VoiceState) is updated a
+Called when a [voice state](VoiceState.md) is updated a
 [voice channel](ChannelVoice.md). The `action` argument can be `l` if a
 [user](User.md) `left` from the guild's channels (or got removed), `j` if the
 user just `joined`, or `u` if the voice state was `updated`. `old` is passed
@@ -575,26 +573,18 @@ Called when a [webhook](Webhook.md) of the [channel](CHANNEL_TYPES.md) is
 updated. Sadly Discord does not sends details, so we pass only the channel as
 argument.
 
-## Static methods
-
-### `DEFAULT_EVENT`
-
-- `awaitable`
-
-The default event. Does nothing at all.
-
 ## Magic methods
 
 ### `__setatrr__`
 
-If an event is set of any clients, what is not [.DEFAULT_EVENT](#DEFAULT_EVENT),
+If an event is set of any clients, what is not `DEFAULT_EVENT`,
 then the event's parser will switch from `OPT` to the normal one, which means,
 it will calculate changes to feed the event with and also will start to ensuring
 the event too.
 
 ### `__delattr__`
 
-Removes the event with switching it to [.DEFAULT_EVENT](#DEFAULT_EVENT).
+Removes the event with switching it to `DEFAULT_EVENT`.
 If non of the clients have this event set, then it switches the
 event's parser to `OPT`.
     

--- a/docs/ref/EventDescriptor.md
+++ b/docs/ref/EventDescriptor.md
@@ -259,7 +259,7 @@ Called, when an [emoji](Emoji.md) is deleted at a [guild](Guild.md).
 
 ### `emoji_edit(client,guild,emoji,old)`
 
-Called when an [emoji](Emoji.md) is edited at a [guild](Guild.md).  The `old`
+Called when an [emoji](Emoji.md) is edited at a [guild](Guild.md). The `old`
 argument is a `dict` of the changed attributes, what contains (`attribute name`,
 `old value`) items.
 
@@ -272,8 +272,8 @@ argument is a `dict` of the changed attributes, what contains (`attribute name`,
 | require_colons            | bool                          |
 | roles                     | set of [Role](Role.md) / None |
 
-Additionally if an [emoji](Emoji.md) is upated it's `.user` instance attribute
-might be set too.
+> If an [emoji](Emoji.md) is upated it's `.user` instance attribute might be
+> set too.
 
 ### `error(client,event,err)`
 

--- a/docs/ref/Guild.md
+++ b/docs/ref/Guild.md
@@ -774,43 +774,40 @@ Syncs the guild's [emojis](Emoji.md) with the given data.
 - items : (`str`, `Any`)
 
 Updates the guild and returns it's old attributes as (attribute name, old value)
-pairs. A lot of attributes have their own dispatch events, so they are ignored.
-Exception at the returned data is only [`features`](#features), because it is
-calculated with [`listdifference`](listdifference.md) and the data contains the
-function's return instead of the actual old value.
+pairs.
 
-| name                      | description                                                                       |
-|---------------------------|-----------------------------------------------------------------------------------|
-| afk_channel               | [ChannelVoice](ChannelVoice.md) / None                                            |
-| afk_timeout               | int                                                                               |
-| available                 | bool                                                                              |
-| banner                    | int                                                                               |
-| booster_count             | int                                                                               |
-| content_filter            | [ContentFilterLevel](ContentFilterLevel.md)                                       |
-| description               | str                                                                               |
-| discovery_splash          | int                                                                               |
-| embed_channel             | [ChannelText](ChannelText.md) / None                                              |
-| embed_enabled             | bool                                                                              |
-| features                  | [listdifference](listdifference.md) return of [GuildFeature](GuildFeature.md)     |
-| has_animated_icon         | bool                                                                              |
-| icon                      | int                                                                               |
-| max_presences             | int                                                                               |
-| max_users                 | int                                                                               |
-| message_notification      | [MessageNotificationLevel](MessageNotificationLevel.md)                           |
-| mfa                       | [MFA](MFA.md)                                                                     |
-| name                      | str                                                                               |
-| owner                     | [User](User.md) / [Client](Client.md)                                             |
-| preferred_locale          | str                                                                               |
-| premium_tier              | int                                                                               |
-| region                    | [VoiceRegion](VoiceRegion.md)                                                     |
-| rules_channel             | [ChannelText](ChannelText.md) / None                                              |
-| splash                    | int                                                                               |
-| system_channel            | [ChannelText](ChannelText.md) / None                                              |
-| system_channel_flags      | [SystemChannelFlag](SystemChannelFlag.md)                                         |
-| vanity_code               | str                                                                               |
-| verification_level        | [VerificationLevel](VerificationLevel.md)                                         |
-| widget_channel            | [ChannelText](ChannelText.md) / None                                              |
-| widget_enabled            | bool                                                                              |
+| name                      | description                                               |
+|---------------------------|-----------------------------------------------------------|
+| afk_channel               | [ChannelVoice](ChannelVoice.md) / None                    |
+| afk_timeout               | int                                                       |
+| available                 | bool                                                      |
+| banner                    | int                                                       |
+| booster_count             | int                                                       |
+| content_filter            | [ContentFilterLevel](ContentFilterLevel.md)               |
+| description               | str                                                       |
+| discovery_splash          | int                                                       |
+| embed_channel             | [ChannelText](ChannelText.md) / None                      |
+| embed_enabled             | bool                                                      |
+| features                  | list of [GuildFeature](GuildFeature.md)                   |
+| has_animated_icon         | bool                                                      |
+| icon                      | int                                                       |
+| max_presences             | int                                                       |
+| max_users                 | int                                                       |
+| message_notification      | [MessageNotificationLevel](MessageNotificationLevel.md)   |
+| mfa                       | [MFA](MFA.md)                                             |
+| name                      | str                                                       |
+| owner                     | [User](User.md) / [Client](Client.md)                     |
+| preferred_locale          | str                                                       |
+| premium_tier              | int                                                       |
+| region                    | [VoiceRegion](VoiceRegion.md)                             |
+| rules_channel             | [ChannelText](ChannelText.md) / None                      |
+| splash                    | int                                                       |
+| system_channel            | [ChannelText](ChannelText.md) / None                      |
+| system_channel_flags      | [SystemChannelFlag](SystemChannelFlag.md)                 |
+| vanity_code               | str                                                       |
+| verification_level        | [VerificationLevel](VerificationLevel.md)                 |
+| widget_channel            | [ChannelText](ChannelText.md) / None                      |
+| widget_enabled            | bool                                                      |
 
 
 ### `_update_no_return(self,data)` (method)

--- a/docs/ref/GuildProfile.md
+++ b/docs/ref/GuildProfile.md
@@ -64,10 +64,13 @@ Updates the guild profile and return None.
 - items : (`str`, `Any`)
 
 Updates the guild profile and returns it's old attributes with
-(`attribute name`, `old value`) items. Exception under it is the
-[`roles`](#roles) attribute, where we call [`listdifference`](listdifference.md)
-function to calculate the difference between the old and the new values and we
-store that at the dict.
+(`attribute name`, `old value`) items.
+
+| name                      | description               |
+|---------------------------|---------------------------|
+| nick                      | str / None                |
+| roles                     | list of [Role](Role.md)   |
+| boosts_since              | datetime / None           |
 
 ### `_set_created(self,data)` (method)
 

--- a/docs/ref/Message.md
+++ b/docs/ref/Message.md
@@ -6,17 +6,10 @@
 
 ### `activity`
 
-- type : [`MessageActivity`](MessageActivity.md)
-- default: `MessageActivity.none`
+- type : [`MessageActivity`](MessageActivity.md) / `NoneType`
+- default: `None`
 
 Sent with "Rich presence" related embeds.
-
-### `activity_party_id`
-
-- type : `str`
-- default : `''`
-
-The message's activity's id if applicable.
 
 ### `application`
 
@@ -389,11 +382,22 @@ Updates the message and returns it's old attribtes with (`attribute name`,
 `old value`) items. Resets
 [`_channel_mentions`](#_channel_mentions-instance-attribute) to unset.
 A special case is if a message is (un)pinned or (un)suppressed , because then
-the returned dict is not containing `'edited'`, only `'pinned'` or `flags`.
-Exception at the returned data are the `'user_mentions'` and `'role_mentions'`.
-At these cases the change is calculated with the
-[`listdifference`](listdifference.md) function, and the returned dict contains
-the function's return.
+the returned dict is not going to contain `'edited'`, only `'pinned'` or
+`flags`.
+
+| name                      | description                                                                                   |
+|---------------------------|-----------------------------------------------------------------------------------------------|
+| activity                  | Nne / [MessageActivity](MessageActivity.md)                                                   |
+| application               | None /[MessageApplication](MessageApplication.md)                                             |
+| content                   | str                                                                                           |
+| cross_mentions            | None / (list of [Channel](CHANNEL_TYPES.md) / [UnknownCrossMention](UnknownCrossMention.md))  |
+| edited                    | None / datetime                                                                               |
+| embeds                    | list of [EmbedCore](EmbedCore.md)                                                             |
+| flags                     | [MessageFlag](MessageFlag.md)                                                                 |
+| mention_everyone          | bool                                                                                          |
+| pinned                    | bool                                                                                          |
+| user_mentions             | None / (list of [User](User.md)) / [lient](Client.md))                                        |
+| role_mentions             | None / (list of [Role](Role.md))                                                              |
 
 ### `_update_no_return(self,data)` (method)
     

--- a/docs/ref/MessageFlag.md
+++ b/docs/ref/MessageFlag.md
@@ -2,7 +2,7 @@
 
 The flags of a [message](Message.md).
 
-- Source : [others.py](https://github.com/HuyaneMatsu/hata/blob/master/hata/others.py)
+- Source : [message.py](https://github.com/HuyaneMatsu/hata/blob/master/hata/message.py)
 
 A message can have 3 type of flags:
 - [`crossposted`](#crossposted)

--- a/docs/ref/PermOW.md
+++ b/docs/ref/PermOW.md
@@ -72,9 +72,20 @@ Hashes the permission overwrite.
 
 Returns the representation of the permission overwrite.
 
-### `__eq__`, `__ne__`
+### `__eq__`
 
 Compares the two permission overwrite.
+
+### `__lt__`, `__gt__`
+
+Compares the two permission overwrite's [`.target`](#target)'s type and id.
+
+Type comparing is first, where permission overwrites with their target's type
+of [`Role`](Role.md) are always less, than permission overwrites of their
+target's type [`User`](User.md).
+
+If the two overwrite's target's type is the same, then their id is being
+compared.
 
 ### `__iter__(self)`
 

--- a/docs/ref/PermOW.md
+++ b/docs/ref/PermOW.md
@@ -81,7 +81,7 @@ Compares the two permission overwrite.
 Compares the two permission overwrite's [`.target`](#target)'s type and id.
 
 Type comparing is first, where permission overwrites with their target's type
-of [`Role`](Role.md) are always less, than permission overwrites of their
+of [`Role`](Role.md) are always "less", than permission overwrites of their
 target's type [`User`](User.md).
 
 If the two overwrite's target's type is the same, then their id is being

--- a/docs/ref/UserFlag.md
+++ b/docs/ref/UserFlag.md
@@ -2,7 +2,7 @@
 
 The hypesquad flags of an account.
 
-- Source : [others.py](https://github.com/HuyaneMatsu/hata/blob/master/hata/others.py)
+- Source : [user.py](https://github.com/HuyaneMatsu/hata/blob/master/hata/user.py)
 
 A user can be part of 9 hypesquad houses:
 - [`discord_employee`](#discord_employee)

--- a/docs/ref/listdifference.md
+++ b/docs/ref/listdifference.md
@@ -1,11 +1,13 @@
 # def `listdifference`
 
-Calculates the difference between two SORTED lists. Returns a tuple with two
+Calculates the difference between two **sorted** lists. Returns a tuple with two
 elements. Both element is a list. First contains the elements, what the first
 input list contains, but the second not. The second contains those what the
 second does, but the first does not.
 
 - Source : [dereaddons_local.py](https://github.com/HuyaneMatsu/hata/blob/master/hata/dereaddons_local.py)
+
+> `None`, ot `set` instance can be passed to the function as well.
 
 ## listdifference(list1,list2) (function)
 

--- a/docs/ref/listdifference.md
+++ b/docs/ref/listdifference.md
@@ -7,7 +7,7 @@ second does, but the first does not.
 
 - Source : [dereaddons_local.py](https://github.com/HuyaneMatsu/hata/blob/master/hata/dereaddons_local.py)
 
-> `None`, ot `set` instance can be passed to the function as well.
+> `None`, or `set` instance can be passed to the function as well.
 
 ## listdifference(list1,list2) (function)
 

--- a/hata/__init__.py
+++ b/hata/__init__.py
@@ -1,5 +1,5 @@
 ﻿# -*- coding: utf-8 -*-
-__version__ = '20191222.1'
+__version__ = '20191224.1'
 
 import sys
 ASYNC_ONLY = ('async_only' in sys.argv) or ('async-only' in sys.argv)

--- a/hata/channel.py
+++ b/hata/channel.py
@@ -737,12 +737,16 @@ class ChannelGuildBase(ChannelBase):
             return overwrites
         if not overwrites_data:
             return overwrites
-            
+        
+        default_role=self.guild.default_role
+        
         for overwrite_data in overwrites_data:
             overwrite=PermOW(overwrite_data)
-            overwrites.append(overwrite)
+            if overwrite.target is default_role:
+                overwrites.insert(0,overwrite)
+            else:
+                overwrites.append(overwrite)
         
-        overwrites.sort()
         return overwrites
     
     def __str__(self):

--- a/hata/channel.py
+++ b/hata/channel.py
@@ -7,7 +7,7 @@ import re
 from collections import deque
 from time import monotonic
 
-from .dereaddons_local import listdifference, weakposlist
+from .dereaddons_local import weakposlist
 from .futures import sleep
 
 from .client_core import CHANNELS
@@ -249,7 +249,7 @@ async def _load_till(client,channel,index):
 #the chunksize is 97, because it means 1 request for _load_till
 class MessageIterator(object):
     __slots__=('_index', '_permission', 'channel', 'chunksize', 'client',)
-    def __init__(self,client,channel,start=0,chunksize=97):
+    def __init__(self,client,channel,chunksize=97):
         self.client     = client
         self.channel    = channel
         self.chunksize  = chunksize
@@ -737,17 +737,12 @@ class ChannelGuildBase(ChannelBase):
             return overwrites
         if not overwrites_data:
             return overwrites
-
-        default_role=self.guild.default_role
             
         for overwrite_data in overwrites_data:
             overwrite=PermOW(overwrite_data)
-
-            if overwrite.target is default_role:
-                overwrites.insert(0,overwrite)
-            else:
-                overwrites.append(overwrite)
-                
+            overwrites.append(overwrite)
+        
+        overwrites.sort()
         return overwrites
     
     def __str__(self):
@@ -930,9 +925,8 @@ class ChannelText(ChannelGuildBase,ChannelTextBase):
             self.slowmode=slowmode
 
         overwrites=self._parse_overwrites(data)
-        difference=listdifference(sorted(self.overwrites),sorted(overwrites))
-        if difference[0] or difference[1]:
-            old['overwrites']=difference
+        if self.overwrites!=overwrites:
+            old['overwrites']=self.overwrites
             self.overwrites=overwrites
 
         self._update_catpos(data,old)
@@ -1243,9 +1237,8 @@ class ChannelVoice(ChannelGuildBase):
             self.user_limit=user_limit
 
         overwrites=self._parse_overwrites(data)
-        difference=listdifference(sorted(self.overwrites),sorted(overwrites))
-        if difference[0] or difference[1]:
-            old['overwrites']=difference
+        if self.overwrites!=overwrites:
+            old['overwrites']=self.overwrites
             self.overwrites=overwrites
 
         self._update_catpos(data,old)
@@ -1436,12 +1429,10 @@ class ChannelGroup(ChannelBase,ChannelTextBase):
             self.icon=icon
         
         users=[User(user) for user in data['recipeents']]
-        users.sort()
-        difference=listdifference(self.users,users)
-        if difference[0] or difference[1]:
+        if self.users!=users:
+            old['users']=self.users
             self.users=users
-            old['users']=difference
-                
+        
         owner_id=int(data['owner_id'])
         if self.owner.id!=owner_id:
             for user in self.users:
@@ -1615,9 +1606,8 @@ class ChannelCategory(ChannelGuildBase):
             self.name=name
 
         overwrites=self._parse_overwrites(data)
-        difference=listdifference(sorted(self.overwrites),sorted(overwrites))
-        if difference[0] or difference[1]:
-            old['overwrites']=difference
+        if self.overwrites!=overwrites:
+            old['overwrites']=self.overwrites
             self.overwrites=overwrites
 
         self._update_catpos(data,old)
@@ -1721,9 +1711,8 @@ class ChannelStore(ChannelGuildBase):
             self.nsfw=nsfw
 
         overwrites=self._parse_overwrites(data)
-        difference=listdifference(sorted(self.overwrites),sorted(overwrites))
-        if difference[0] or difference[1]:
-            old['overwrites']=difference
+        if self.overwrites!=overwrites:
+            old['overwrites']=self.overwrites
             self.overwrites=overwrites
 
         self._update_catpos(data,old)

--- a/hata/client.py
+++ b/hata/client.py
@@ -2490,9 +2490,10 @@ class Client(UserBase):
     async def emoji_delete(self,emoji,reason=None):
         await self.http.emoji_delete(emoji.guild.id,emoji.id,reason=reason)
 
-    async def emoji_edit(self,emoji,name=None,roles=[],reason=None):
+    async def emoji_edit(self,emoji,name=None,roles=None,reason=None):
         data={}
         
+        # name is required
         if (name is None):
             data['name']=emoji.name
         else:
@@ -2502,11 +2503,13 @@ class Client(UserBase):
                 raise ValueError(f'The length of the name can be between 2-32, got {name_ln}')
             
             data['name']=name
-
-        data['roles']=[role.id for role in roles]
+        
+        # roles are not required
+        if (roles is not None):
+            data['roles']=[role.id for role in roles]
         
         await self.http.emoji_edit(emoji.guild.id,emoji.id,data,reason)
-    
+        
     # Invite management
         
     async def vanity_invite(self,guild):

--- a/hata/client.py
+++ b/hata/client.py
@@ -13,13 +13,13 @@ from .futures import Future, Task, sleep, CancelledError
 from .py_formdata import Formdata
 from .py_hdrs import AUTHORIZATION
 
-from .others import Status, UserFlag, log_time_converter, _parse_ih_fsa,    \
+from .others import Status, id_to_time, log_time_converter, _parse_ih_fsa,  \
     VoiceRegion, ContentFilterLevel, PremiumType, MessageNotificationLevel, \
     bytes_to_base64, FriendRequestFlag, ext_from_base64, Theme, now_as_id,  \
     to_json, multi_delete_time_limit, VerificationLevel, RelationshipType,  \
-    random_id, parse_time, id_to_time
+    random_id, parse_time
 
-from .user import User, USERS, GuildProfile, UserBase
+from .user import User, USERS, GuildProfile, UserBase, UserFlag
 from .emoji import Emoji, PartialEmoji
 from .channel import ChannelCategory, ChannelGuildBase, ChannelPrivate,     \
     ChannelText, ChannelGroup, message_relativeindex, cr_pg_channel_object, \
@@ -70,7 +70,7 @@ class single_user_chunker(object):
         self.waiter.set_result_if_pending(users)
         timer=self.timer
         if timer is not None:
-            self.timer.cancel()
+            timer.cancel()
             self.timer=None
         return True
 

--- a/hata/dereaddons_local.py
+++ b/hata/dereaddons_local.py
@@ -613,11 +613,11 @@ class titledstr(str):
         return str.__new__(cls,value)
 
     @classmethod
-    def by_pass_titling(cls,value='',encoding=sys.getdefaultencoding(),errors='strict'):
+    def bypass_titling(cls,value='',encoding=sys.getdefaultencoding(),errors='strict'):
         if type(value)==cls:
             return value
         if isinstance(value,(bytes, bytearray, memoryview)):
-            val=str(value,encoding,errors)
+            value=str(value,encoding,errors)
         elif isinstance(value,str):
             pass
         else:
@@ -628,9 +628,26 @@ class titledstr(str):
         return self
 
 def listdifference(list1,list2):
+    result=([],[])
+    
+    if list1 is None:
+        if list2 is None:
+            return result
+        else:
+            result[1].extend(list2)
+            return result
+    else:
+        if list2 is None:
+            result[0].extend(list1)
+            return result
+    
+    if isinstance(list1,set):
+        list1=sorted(list1)
+    if isinstance(list2,set):
+        list2=sorted(list2)
+        
     ln1=len(list1)
     ln2=len(list2)
-    result=([],[])       
     index1=index2=0
 
     #some quality python here again *cough*

--- a/hata/embed.py
+++ b/hata/embed.py
@@ -5,8 +5,8 @@ __all__ = ('EXTRA_EMBED_TYPES', 'Embed', 'EmbedAuthor', 'EmbedCore',
 
 import re
 
-from .others import parse_time, USER_MENTION_RP, CHANNEL_MENTION_RP,        \
-    ROLE_MENTION_RP
+from .others import ROLE_MENTION_RP, USER_MENTION_RP, CHANNEL_MENTION_RP,   \
+    parse_time, urlcutter
 from .color import Color
 
 EXTRA_EMBED_TYPES=('link', 'video', 'gifv', 'image')
@@ -65,84 +65,6 @@ def _convert_content(content,message):
         
         return re.compile("|".join(transformations)).sub(lambda mention:transformations[escape(mention.group(0))],content)
 
-def _urlcutter(url):
-    if len(url)<50:
-        return url
-    
-    position=url.find('/')
-    
-    if position==-1:
-        return f'{url[:28]}...{url[-19:]}'
-    
-    position=position+1
-    if url[position]=='/':
-        position=position+1
-        if position==len(url):
-            return f'{url[:28]}...{url[-19:]}'
-        
-        position=url.find('/',position)
-        position=position+1
-        if position==0 or position==len(url):
-            return f'{url[:28]}...{url[-19:]}'
-    
-    positions=[position]
-    
-    while True:
-        position=url.find('/',position)
-        if position==-1:
-            break
-        position=position+1
-        if position==len(url):
-            break
-        positions.append(position)
-
-    from_start=0
-    from_end=0
-    top_limit=len(url)
-    index=0
-    
-    while True:
-        value=positions[index]
-        if value+from_end>47:
-            if from_start+from_end<33:
-                from_start=47-from_end
-                break
-            else:
-                index=index+1
-                if index==len(positions):
-                    value=0
-                else:
-                    value=positions[len(positions)-index]
-                value=top_limit-value
-                if value+from_start>47:
-                    break
-                else:
-                    from_end=value
-                    break
-        from_start=value
-        
-        index=index+1
-        value=positions[len(positions)-index]
-        value=top_limit-value
-        if value+from_start>47:
-            if from_start+from_end<33:
-                from_end=47-from_start
-                break
-            else:
-                if index==len(positions):
-                    value=top_limit
-                else:
-                    value=positions[index]
-                
-                if value+from_end>47:
-                    break
-                else:
-                    from_start=value
-                    break
-        from_end=value
-        
-    return f'{url[:from_start]}...{url[top_limit-from_end-1:]}'
-
 class EmbedThumbnail(object):
     __slots__=('height', 'proxy_url', 'url', 'width',)
     def __init__(self,url):
@@ -181,7 +103,7 @@ class EmbedThumbnail(object):
             text.append('None')
         else:
             text.append('\'')
-            url=_urlcutter(url)
+            url=urlcutter(url)
             text.append(url)
             text.append('\'')
         
@@ -241,7 +163,7 @@ class EmbedVideo(object):
             text.append('None')
         else:
             text.append('\'')
-            url=_urlcutter(url)
+            url=urlcutter(url)
             text.append(url)
             text.append('\'')
         
@@ -304,7 +226,7 @@ class EmbedImage(object):
             text.append('None')
         else:
             text.append('\'')
-            url=_urlcutter(url)
+            url=urlcutter(url)
             text.append(url)
             text.append('\'')
             
@@ -364,7 +286,7 @@ class EmbedProvider(object):
             text.append('None')
         else:
             text.append('\'')
-            url=_urlcutter(url)
+            url=urlcutter(url)
             text.append(url)
             text.append('\'')
         
@@ -451,7 +373,7 @@ class EmbedAuthor(object):
             text.append('None')
         else:
             text.append('\'')
-            url=_urlcutter(url)
+            url=urlcutter(url)
             text.append(url)
             text.append('\'')
         
@@ -461,7 +383,7 @@ class EmbedAuthor(object):
             text.append('None')
         else:
             text.append('\'')
-            icon_url=_urlcutter(icon_url)
+            icon_url=urlcutter(icon_url)
             text.append(icon_url)
             text.append('\'')
             
@@ -543,7 +465,7 @@ class EmbedFooter(object):
             text.append('None')
         else:
             text.append('\'')
-            icon_url=_urlcutter(icon_url)
+            icon_url=urlcutter(icon_url)
             text.append(icon_url)
             text.append('\'')
         

--- a/hata/emoji.py
+++ b/hata/emoji.py
@@ -83,10 +83,10 @@ class Emoji(object):
         try:
             role_ids=data['roles']
         except KeyError:
-            emoji.roles=guild.roles
+            emoji.roles=None
         else:
-            emoji.roles=[guild.all_role[int(role_id)] for role_id in role_ids]
-
+            emoji.roles={guild.all_role[int(role_id)] for role_id in role_ids}
+        
         return emoji
 
     def __gt__(self,other):
@@ -215,9 +215,9 @@ class Emoji(object):
     
     def _delete(self):
         del self.guild.emojis[self.id]
-        del self.roles
+        self.roles = None
         self.guild = None
-        self.available=False
+        self.available = False
         
     def _update_no_return(self,data):
         guild=self.guild
@@ -234,12 +234,12 @@ class Emoji(object):
         self.name=name
         
         try:
-            roles=data['roles']
+            role_ids=data['roles']
         except KeyError:
-            self.roles=guild.roles
+            self.roles=None
         else:
-            self.roles=[guild.all_role[int(role_id)] for role_id in roles]
-
+            self.roles={guild.all_role[int(role_id)] for role_id in role_ids}
+        
         try:
             user_data=data['user']
         except KeyError:
@@ -276,22 +276,31 @@ class Emoji(object):
             self.name=name
         
         try:
-            roles=data['roles']
+            role_ids=data['roles']
         except KeyError:
-            roles=guild.roles
+            roles=None
         else:
-            roles=[guild.all_role[int(role_id)] for role_id in roles]
-        if self.roles!=roles:
-            old['roles']=self.roles
-            self.roles=roles
-
+            roles={guild.all_role[int(role_id)] for role_id in role_ids}
+        
+        if (self.roles is None):
+            if (roles is not None):
+                old['roles']=None
+                self.roles=roles
+        else:
+            if (roles is None):
+                old['roles']=self.roles
+                self.roles=None
+            elif self.roles!=roles:
+                old['roles']=self.roles
+                self.roles=roles
+        
         try:
             user_data=data['user']
         except KeyError:
             pass
         else:
             self.user=User(user_data)
-
+        
         available=data.get('available',True)
         if self.available!=available:
             old['available']=self.available

--- a/hata/events.py
+++ b/hata/events.py
@@ -12,8 +12,8 @@ from weakref import WeakKeyDictionary
 from .futures import Task, Future
 
 from .others import USER_MENTION_RP
-from .parsers import check_passed, EventHandlerBase, EventDescriptor,       \
-    compare_converted, check_name, check_passed_tuple, asynclist
+from .parsers import check_passed, EventHandlerBase, compare_converted,     \
+    check_name, check_passed_tuple, asynclist, DEFAULT_EVENT
 from .emoji import BUILTIN_EMOJIS
 from .exceptions import DiscordException
 from .client_core import KOKORO
@@ -29,8 +29,8 @@ class CommandProcesser(EventHandlerBase):
         'mention_prefix', 'prefix', 'prefixfilter', 'waitfors',)
     __event_name__='message_create'
     def __init__(self,prefix,ignorecase=True,mention_prefix=True):
-        self.default_event=EventDescriptor.DEFAULT_EVENT
-        self.invalid_command=EventDescriptor.DEFAULT_EVENT
+        self.default_event=DEFAULT_EVENT
+        self.invalid_command=DEFAULT_EVENT
         self.mention_prefix=mention_prefix
         self.waitfors=WeakKeyDictionary()
         self.commands={}
@@ -103,13 +103,13 @@ class CommandProcesser(EventHandlerBase):
     def __delevent__(self,func,case):
         if case=='default_event':
             if func is self.default_event:
-                self.default_event=EventDescriptor.DEFAULT_EVENT
+                self.default_event=DEFAULT_EVENT
             else:
                 raise ValueError(f'The passed \'{case}\' ({func!r}) is not the same as the already loaded one: {self.default_event!r}')
         
         elif case=='invalid_command':
             if func is self.invalid_command:
-                self.invalid_command=EventDescriptor.DEFAULT_EVENT
+                self.invalid_command=DEFAULT_EVENT
             else:
                 raise ValueError(f'The passed \'{case}\' ({func!r}) is not the same as the already loaded one: {self.invalid_command!r}')
         
@@ -216,12 +216,12 @@ class CommandProcesser(EventHandlerBase):
                 ]
         
         default_event=self.default_event
-        if default_event is not EventDescriptor.DEFAULT_EVENT:
+        if default_event is not DEFAULT_EVENT:
             result.append(', default_event=')
             result.append(default_event.__repr__())
         
         invalid_command=self.invalid_command
-        if invalid_command is not EventDescriptor.DEFAULT_EVENT:
+        if invalid_command is not DEFAULT_EVENT:
             result.append(', invalid_command=')
             result.append(invalid_command.__repr__())
         
@@ -736,7 +736,7 @@ class Cooldown(object):
         
         if func is None:
             self.__name__=case
-            self.__func__=EventDescriptor.DEFAULT_EVENT
+            self.__func__=DEFAULT_EVENT
             return self._wrapper
         
         self.__name__=check_name(func,case)
@@ -775,7 +775,7 @@ class Cooldown(object):
             
         if func is None:
             self.__name__=case
-            self.__func__=EventDescriptor.DEFAULT_EVENT
+            self.__func__=DEFAULT_EVENT
             return self._wrapper
         
         self.__name__=check_name(func,case)

--- a/hata/events.py
+++ b/hata/events.py
@@ -210,9 +210,9 @@ class CommandProcesser(EventHandlerBase):
     def __repr__(self):
         result = [
             '<', self.__class__.__name__,
-            ' prefix=', self.prefix.__repr__(),
-            ', command count=', self.commands.__len__().__repr__(),
-            ', mention_prefix=', self.mention_prefix.__repr__(),
+            ' prefix=', repr(self.prefix),
+            ', command count=', repr(len(self.commands)),
+            ', mention_prefix=', repr(self.mention_prefix),
                 ]
         
         default_event=self.default_event

--- a/hata/events_compiler.py
+++ b/hata/events_compiler.py
@@ -21,6 +21,7 @@ from .user import USERS
 from .exceptions import DiscordException
 from .emoji import parse_emoji
 from .client_core import CACHE_USER
+from .parsers import DEFAULT_EVENT
 
 #for types at eval testing
 from . import client
@@ -284,6 +285,7 @@ class ParserMeta(object):
                 raise ValueError('For {self.name} \'default\' should have been passed')
             return value
         return ''
+
 #          name         flags_name  flags_default   flags_all       passing_enabled mode_enabled    default_enabled default_must
 ParserMeta('user',      '',         'mni',          'gmniap',       True,           True,           True,           False,          )
 ParserMeta('role',      'g',        'gmni',         'gmni',         True,           True,           True,           False,          )
@@ -1139,7 +1141,7 @@ class ContentParser(object):
         
         if func is None:
             self.__name__=case
-            self.__func__=EventDescriptor.DEFAULT_EVENT
+            self.__func__=DEFAULT_EVENT
             return self._wrapper
         
         self.__name__=check_name(func,case)

--- a/hata/guild.py
+++ b/hata/guild.py
@@ -1464,7 +1464,7 @@ class Guild(object):
                 old_ids.remove(emoji_id)
         for emoji_id in old_ids:
             emoji=emojis[emoji_id]
-            del emojis[emoji_id]
+            emoji._delete()
             changes.append((EMOJI_UPDATE_DELETE,emoji,None),)
 
         return changes

--- a/hata/http.py
+++ b/hata/http.py
@@ -992,7 +992,18 @@ class DiscordHTTPClient(object):
             if err.response.status==404: #404==already deleted message
                 return
             raise
-            
+    
+    # after 2 week else
+    async def message_delete_a2wo(self,channel_id,message_id,reason):
+        try:
+            result = await self.request(ratelimit_handler(self.loop,channel_id,87808),METH_DELETE,
+                f'{API_ENDPOINT}/channels/{channel_id}/messages/{message_id}',reason=reason)
+            return result
+        except DiscordException as err:
+            if err.code == 10008: # 10008==already deleted message
+                return
+            raise
+    
     async def message_delete_multiple(self,channel_id,data,reason):
         return await self.request(ratelimit_handler(self.loop,channel_id,30464),METH_POST,
             f'{API_ENDPOINT}/channels/{channel_id}/messages/bulk_delete',data,reason=reason)

--- a/hata/invite.py
+++ b/hata/invite.py
@@ -1,11 +1,40 @@
 # -*- coding: utf-8 -*-
-__all__ = ('Invite', )
+__all__ = ('Invite', 'InviteTargetType')
 
-from .others import parse_time, InviteTargetType
+from .others import parse_time
 from .http import URLS
 from .user import User,ZEROUSER
 from .guild import PartialGuild
 from .channel import PartialChannel
+
+class InviteTargetType(object):
+    # class related
+    INSTANCES = [NotImplemented] * 2
+    
+    # object related
+    __slots__=('name', 'value')
+    
+    def __init__(self,value,name):
+        self.value=value
+        self.name=name
+
+        self.INSTANCES[value]=self
+
+    def __str__(self):
+        return self.name
+
+    def __int__(self):
+        return self.value
+
+    def __repr__(self):
+        return f'{self.__class__.__name__}(value={self.value}, name=\'{self.name}\')'
+    
+    # predefined
+    NONE    = NotImplemented
+    STREAM  = NotImplemented
+
+InviteTargetType.NONE   = InviteTargetType(0,'NONE')
+InviteTargetType.STREAM = InviteTargetType(1,'STREAM')
 
 class Invite(object):
     __slots__=('channel', 'code', 'created_at', 'guild', 'inviter', 'max_age',

--- a/hata/message.py
+++ b/hata/message.py
@@ -128,7 +128,11 @@ class Attachment(object):
         self.url        = data['url']
         self.height     = data.get('height',0)
         self.width      = data.get('width',0)
-
+    
+    @property
+    def created_at(self):
+        return id_to_time(self.id)
+    
     def __gt__(self,other):
         if type(self) is type(other):
             return self.id>other.id
@@ -162,6 +166,26 @@ class Attachment(object):
     def __hash__(self):
         return self.id
     
+    def __repr__(self):
+        result = [
+            '<',self.__class__.__name__,
+            ' id=',repr(self.id),
+            ', name=',repr(self.name),
+                ]
+        
+        x=self.width
+        y=self.height
+        if x and y:
+            result.append(', size=')
+            result.append(repr(x))
+            result.append('x')
+            result.append(repr(y))
+        
+        result.append('>')
+        
+        return ''.join(result)
+        
+
 class MessageApplication(object):
     __slots__=('cover', 'description', 'icon', 'id', 'name',)
     def __init__(self,data):

--- a/hata/oauth2.py
+++ b/hata/oauth2.py
@@ -1,11 +1,12 @@
 ﻿# -*- coding: utf-8 -*-
-__all__ = ('AO2Access', 'UserOA2', )
+__all__ = ('AO2Access', 'UserOA2', 'parse_oauth2_redirect_url')
 
+import re
 from datetime import datetime
 
 from .integration import Integration
-from .others import UserFlag, PremiumType
-from .user import UserBase
+from .others import PremiumType
+from .user import UserBase, UserFlag
 
 DEFAULT_LOCALE='en-US'
 LOCALES={DEFAULT_LOCALE:DEFAULT_LOCALE}
@@ -48,7 +49,15 @@ def parse_locale_optional(data):
         LOCALES[locale]=locale
     
     return locale
-    
+
+OA2_RU_RP=re.compile('(https{0,1}://.+?)\?code=([a-zA-Z0-9]{30})')
+
+def parse_oauth2_redirect_url(url):
+    result=OA2_RU_RP.fullmatch(url)
+    if result is None:
+        raise ValueError
+    return result.groups()
+
 class Connection(object):
     __slots__=('friend_sync', 'id', 'integrations', 'name', 'revoked',
         'show_activity', 'type', 'verified', 'visibility',)
@@ -158,4 +167,4 @@ class UserOA2(UserBase):
     def is_bot(self):
         return False
 
-del UserBase
+del UserBase, re

--- a/hata/others.py
+++ b/hata/others.py
@@ -1,12 +1,11 @@
 ﻿# -*- coding: utf-8 -*-
 __all__ = ('Relationship', 'ContentFilterLevel', 'DISCORD_EPOCH',
-    'FriendRequestFlag', 'Gift', 'HypesquadHouse', 'InviteTargetType', 'MFA',
-    'MessageActivity', 'MessageFlag', 'MessageNotificationLevel',
-    'MessageType', 'PremiumType', 'RelationshipType', 'Status',
-    'SystemChannelFlag', 'Theme', 'Unknown', 'UserFlag', 'VerificationLevel',
+    'FriendRequestFlag', 'Gift', 'HypesquadHouse', 'MFA',
+    'MessageNotificationLevel', 'PremiumType', 'RelationshipType', 'Status',
+    'SystemChannelFlag', 'Theme', 'Unknown', 'VerificationLevel',
     'VoiceRegion', 'filter_content', 'id_to_time', 'is_id', 'is_mention',
-    'is_role_mention', 'is_user_mention', 'now_as_id',
-    'parse_oauth2_redirect_url', 'random_id', 'time_to_id', )
+    'is_role_mention', 'is_user_mention', 'now_as_id', 'random_id',
+    'time_to_id', )
 
 import random, re, sys
 from urllib.parse import _ALWAYS_SAFE_BYTES as ALWAYS_SAFE_BYTES,Quoter
@@ -505,126 +504,6 @@ PremiumType.none            = PremiumType(0,'none')
 PremiumType.nitro_classic   = PremiumType(1,'nitro_classic')
 PremiumType.nitro           = PremiumType(2,'nitro')
 
-class UserFlag(int):
-    __slots__=()
-    
-    @property
-    def discord_employee(self):
-        return self&1
-    
-    @property
-    def discord_partner(self):
-        return (self>>1)&1
-    
-    @property
-    def hypesquad_events(self):
-        return (self>>2)&1
-    
-    @property
-    def bug_hunter(self):
-        return (self>>3)&1
-    
-    @property
-    def hypesquad_bravery(self):
-        return (self>>6)&1
-    
-    @property
-    def hypesquad_brilliance(self):
-        return (self>>7)&1
-    
-    @property
-    def hypesquad_balance(self):
-        return (self>>8)&1
-    
-    @property
-    def early_supporter(self):
-        return (self>>9)&1
-    
-    @property
-    def team_user(self):
-        return (self>>10)&1
-    
-    @property
-    def system(self):
-        return (self>>11)&1
-    
-    def __iter__(self):
-        if self&1:
-            yield 'discord_employee'
-            
-        if (self>>1)&1:
-            yield 'discord_partner'
-            
-        if (self>>2)&1:
-            yield 'bug_hunter'
-            
-        if (self>>3)&1:
-            yield 'hypesquad_bravery'
-            
-        if (self>>6)&1:
-            yield 'hypesquad_bravery'
-            
-        if (self>>7)&1:
-            yield 'hypesquad_brilliance'
-            
-        if (self>>8)&1:
-            yield 'hypesquad_balance'
-            
-        if (self>>9)&1:
-            yield 'early_supporter'
-            
-        if (self>>10)&1:
-            yield 'team_user'
-
-        if (self>>11)&1:
-            yield 'system'
-            
-    def __repr__(self):
-        return f'{self.__class__.__name__}({int.__repr__(self)})'
-
-class MessageFlag(int):
-    __slots__=()
-
-    @property
-    def crossposted(self):
-        return self&1
-
-    @property
-    def is_crosspost(self):
-        return (self>>1)&1
-
-    @property
-    def embeds_suppressed(self):
-        return (self>>2)&1
-
-    
-    @property
-    def source_message_deleted(self):
-        return (self>>3)&1
-    
-    @property
-    def urgent(self):
-        return (self>>4)&1
-    
-    def __iter__(self):
-        if self&1:
-            yield 'crossposted'
-            
-        if (self>>1)&1:
-            yield 'is_crosspost'
-            
-        if (self>>2)&1:
-            yield 'embeds_suppressed'
-
-        if (self>>3)&1:
-            yield 'source_message_deleted'
-
-        if (self>>4)&1:
-            yield 'urgent'
-            
-    def __repr__(self):
-        return f'{self.__class__.__name__}({int.__repr__(self)})'
-
 class RelationshipType(object):
     #class related
     INSTANCES = [NotImplemented] * 5
@@ -670,97 +549,6 @@ class Relationship(object):
     def __repr__(self):
         return f'<{self.__class__.__name__} {self.type.name} user={self.user.full_name}>'
 
-
-class MessageType(object):
-    # class related
-    INSTANCES = [NotImplemented] * 13
-    
-    # object related
-    __slots__=('name', 'value', 'convert',)
-    
-    def __init__(self,value,name):
-        self.value=value
-        self.name=name
-        self.convert=self._default_convert
-
-        self.INSTANCES[value]=self
-
-    def __str__(self):
-        return self.name
-
-    def __int__(self):
-        return self.value
-
-    def __repr__(self):
-        return f'{self.__class__.__name__}(value={self.value}, name=\'{self.name}\')'
-
-    @staticmethod
-    def _default_convert(self):
-        pass
-    
-    # predefined
-    default                 = NotImplemented
-    add_user                = NotImplemented
-    remove_user             = NotImplemented
-    call                    = NotImplemented
-    channel_name_change     = NotImplemented
-    channel_icon_change     = NotImplemented
-    new_pin                 = NotImplemented
-    new_member              = NotImplemented
-    new_guild_sub           = NotImplemented
-    new_guild_sub_t1        = NotImplemented
-    new_guild_sub_t2        = NotImplemented
-    new_guild_sub_t3        = NotImplemented
-    new_follower_channel    = NotImplemented
-
-MessageType.default               = MessageType(0,'default')
-MessageType.add_user              = MessageType(1,'add_user')
-MessageType.remove_user           = MessageType(2,'remove_user')
-MessageType.call                  = MessageType(3,'call')
-MessageType.channel_name_change   = MessageType(4,'channel_name_change')
-MessageType.channel_icon_change   = MessageType(5,'channel_icon_change')
-MessageType.new_pin               = MessageType(6,'new_pin')
-MessageType.new_member            = MessageType(7,'new_member')
-MessageType.new_guild_sub         = MessageType(8,'new_guild_sub')
-MessageType.new_guild_sub_t1      = MessageType(9,'new_guild_sub_t1')
-MessageType.new_guild_sub_t2      = MessageType(10,'new_guild_sub_t2')
-MessageType.new_guild_sub_t3      = MessageType(11,'new_guild_sub_t3')
-MessageType.new_follower_channel  = MessageType(12,'new_follower_channel')
-
-class MessageActivity(object):
-    # class related
-    INSTANCES = [NotImplemented] * 6
-    
-    # object related
-    __slots__=('name', 'value', )
-    
-    def __init__(self,value,name):
-        self.value=value
-        self.name=name
-
-        self.INSTANCES[value]=self
-
-    def __str__(self):
-        return self.name
-
-    def __int__(self):
-        return self.value
-
-    def __repr__(self):
-        return f'{self.__class__.__name__}(value={self.value}, name=\'{self.name}\')'
-
-    none        = NotImplemented
-    join        = NotImplemented
-    spectate    = NotImplemented
-    listen      = NotImplemented
-    join_request= NotImplemented
-
-MessageActivity.none           = MessageActivity(0,'none')
-MessageActivity.join           = MessageActivity(1,'join')
-MessageActivity.spectate       = MessageActivity(2,'spectate')
-MessageActivity.listen         = MessageActivity(3,'listen')
-MessageActivity.join_request   = MessageActivity(5,'join_request')
-
 def multi_delete_time_limit():
     #2 weeks-1 minute since now, so if we delete a lot of messages, it wont mess up
     return int((time_now()-1209540.)*1000.-DISCORD_EPOCH)<<22
@@ -785,7 +573,6 @@ ROLE_MENTION_RP=re.compile('<@&(\d{7,21})>')
 EMOJI_RP=re.compile('<([a]{0,1}):([a-zA-Z0-9_]{2,32}(~[1-9]){0,1}):(\d{7,21})>')
 EMOJI_NAME_RP=re.compile(':{0,1}([a-zA-Z0-9_\\-~]{1,32}):{0,1}')
 FILTER_RP=re.compile('("(.+?)"|\S+)')
-OA2_RU_RP=re.compile('(https{0,1}://.+?)\?code=([a-zA-Z0-9]{30})')
 
 def is_id(text):
     return IS_ID_RP.fullmatch(text) is not None
@@ -808,13 +595,6 @@ def now_as_id():
 #thanks Pythonic#6090 for the simple design
 def filter_content(content):
     return [match[1] or match[0] for match in FILTER_RP.findall(content)]
-
-def parse_oauth2_redirect_url(url):
-    result=OA2_RU_RP.fullmatch(url)
-    if result is None:
-        raise ValueError
-    return result.groups()
-
 
 def chunkify(lines,limit=2000):
     result=[]
@@ -969,36 +749,6 @@ class Unknown(object):
     @property
     def created_at(self):
         return id_to_time(self.id)
-    
-class InviteTargetType(object):
-    # class related
-    INSTANCES = [NotImplemented] * 2
-    
-    # object related
-    __slots__=('name', 'value')
-    
-    def __init__(self,value,name):
-        self.value=value
-        self.name=name
-
-        self.INSTANCES[value]=self
-
-    def __str__(self):
-        return self.name
-
-    def __int__(self):
-        return self.value
-
-    def __repr__(self):
-        return f'{self.__class__.__name__}(value={self.value}, name=\'{self.name}\')'
-    
-    # predefined
-    NONE    = NotImplemented
-    STREAM  = NotImplemented
-
-InviteTargetType.NONE   = InviteTargetType(0,'NONE')
-InviteTargetType.STREAM = InviteTargetType(1,'STREAM')
-
 
 #parse image hash formats
 def _parse_ih_fs(value):
@@ -1121,7 +871,7 @@ Theme.dark  = Theme('dark')
 Theme.light = Theme('light')
 
 class SystemChannelFlag(int):
-    __slots__=[]
+    __slots__=()
     
     @property
     def none(self):
@@ -1142,6 +892,7 @@ class SystemChannelFlag(int):
     def __iter__(self):
         if not self&1:
             yield 'welcome'
+        
         if not (self>>1)&1:
             yield 'boost'
 
@@ -1169,7 +920,85 @@ class Discord_hdrs:
     RATELIMIT_RESET_AFTER=titledstr('X-Ratelimit-Reset-After')
 
     #to send
-    RATELIMIT_PRECISION=titledstr.by_pass_titling('X-RateLimit-Precision')
+    RATELIMIT_PRECISION=titledstr.bypass_titling('X-RateLimit-Precision')
+
+def urlcutter(url):
+    if len(url)<50:
+        return url
+    
+    position=url.find('/')
+    
+    if position==-1:
+        return f'{url[:28]}...{url[-19:]}'
+    
+    position=position+1
+    if url[position]=='/':
+        position=position+1
+        if position==len(url):
+            return f'{url[:28]}...{url[-19:]}'
+        
+        position=url.find('/',position)
+        position=position+1
+        if position==0 or position==len(url):
+            return f'{url[:28]}...{url[-19:]}'
+    
+    positions=[position]
+    
+    while True:
+        position=url.find('/',position)
+        if position==-1:
+            break
+        position=position+1
+        if position==len(url):
+            break
+        positions.append(position)
+
+    from_start=0
+    from_end=0
+    top_limit=len(url)
+    index=0
+    
+    while True:
+        value=positions[index]
+        if value+from_end>47:
+            if from_start+from_end<33:
+                from_start=47-from_end
+                break
+            else:
+                index=index+1
+                if index==len(positions):
+                    value=0
+                else:
+                    value=positions[len(positions)-index]
+                value=top_limit-value
+                if value+from_start>47:
+                    break
+                else:
+                    from_end=value
+                    break
+        from_start=value
+        
+        index=index+1
+        value=positions[len(positions)-index]
+        value=top_limit-value
+        if value+from_start>47:
+            if from_start+from_end<33:
+                from_end=47-from_start
+                break
+            else:
+                if index==len(positions):
+                    value=top_limit
+                else:
+                    value=positions[index]
+                
+                if value+from_end>47:
+                    break
+                else:
+                    from_start=value
+                    break
+        from_end=value
+        
+    return f'{url[:from_start]}...{url[top_limit-from_end-1:]}'
 
 del re, titledstr, modulize
 

--- a/hata/prettyprint.py
+++ b/hata/prettyprint.py
@@ -1335,7 +1335,8 @@ def str_emoji(emoji,index=None,**kwargs):
     
     if not emoji.require_colons:
         result.append('- no colons required',1)
-        
+    
+    return result
     
 PRETTY_PRINTERS['Message']=str_message
 PRETTY_PRINTERS['reaction_mapping']=str_reaction_mapping

--- a/hata/ratelimit.py
+++ b/hata/ratelimit.py
@@ -271,12 +271,15 @@ GLOBALLY_LIMITED=0x4000000000000000
 ##endpoint: /channels/{channel_id}/messages/{message_id}
 ##method  : DELETE
 ##auth    : bot
-##used at : message_delete
+##used at : message_delete / message_delete_a2wo
 ##limits  : `newer than 14 days` or `own` / `else`
-##    group   : 71680
+##    group   : 71680 / 87808
 ##    limit   : 3 / 30
-##    reset   : 2 / 120
+##    reset   : 1 / 120
 ##    limiter : channel_id
+##comment :
+##    For newer messages ratelimit is not every time included, but we ll ignore
+##    those, because we cannot detect, at which cases ar those applied.
 ##
 ##endpoint: /channels/{channel_id}/messages/{message_id}
 ##method  : GET

--- a/hata/role.py
+++ b/hata/role.py
@@ -321,18 +321,53 @@ class PermOW(object):
         if type(self.target) is Role:
             return 'role'
         return 'member'
-
+    
+    def __lt__(self,other):
+        if type(self) is not type(other):
+            return NotImplemented
+        
+        if type(self.target) is Role:
+            if type(other.target) is Role:
+                if self.target.id<other.target.id:
+                    return True
+                return False
+            return True
+        if type(other.target) is Role:
+            return True
+        if self.target.id<other.target.id:
+            return True
+        return False
+        
     def __eq__(self,other):
-        if type(self) is type(other):
-            return (self.target.id==other.target.id and
-                self.allow==other.allow and self.deny==other.deny)
-        return NotImplemented
-
-    def __ne__(self,other):
-        if type(self) is type(other):
-            return (self.target.id!=other.target.id or
-            self.allow!=other.allow or self.deny!=other.deny)
-        return NotImplemented
+        if type(self) is not type(other):
+            return NotImplemented
+        
+        if self.target.id!=other.target.id:
+            return False
+        
+        if self.allow!=other.allow:
+            return False
+        
+        if self.deny!=other.deny:
+            return False
+        
+        return True
+    
+    def __gt__(self,other):
+        if type(self) is not type(other):
+            return NotImplemented
+        
+        if type(self.target) is Role:
+            if type(other.target) is Role:
+                if self.target.id>other.target.id:
+                    return True
+                return False
+            return False
+        if type(other.target) is Role:
+            return False
+        if self.target.id>other.target.id:
+            return True
+        return True
     
 def cr_p_role_object(name,id_=None,color=Color(0),separated=False,position=0,
         permissions=0,managed=False,mentionable=False):

--- a/hata/user.py
+++ b/hata/user.py
@@ -1,15 +1,93 @@
 # -*- coding: utf-8 -*-
-__all__ = ('GuildProfile', 'User', 'UserBase', 'VoiceState', 'ZEROUSER')
+__all__ = ('GuildProfile', 'User', 'UserBase', 'UserFlag', 'VoiceState',
+    'ZEROUSER')
 
 from datetime import datetime
 
-from .dereaddons_local import any_to_any, listdifference, modulize
+from .dereaddons_local import any_to_any, modulize
 
 from .client_core import CACHE_USER,CACHE_PRESENCE, USERS
 from .others import parse_time, Status, DISCORD_EPOCH, id_to_time, _parse_ih_fsa
 from .color import Color, DefaultAvatar
 from .activity import ActivityUnknown, Activity
 from .http import URLS
+
+class UserFlag(int):
+    __slots__=()
+    
+    @property
+    def discord_employee(self):
+        return self&1
+    
+    @property
+    def discord_partner(self):
+        return (self>>1)&1
+    
+    @property
+    def hypesquad_events(self):
+        return (self>>2)&1
+    
+    @property
+    def bug_hunter(self):
+        return (self>>3)&1
+    
+    @property
+    def hypesquad_bravery(self):
+        return (self>>6)&1
+    
+    @property
+    def hypesquad_brilliance(self):
+        return (self>>7)&1
+    
+    @property
+    def hypesquad_balance(self):
+        return (self>>8)&1
+    
+    @property
+    def early_supporter(self):
+        return (self>>9)&1
+    
+    @property
+    def team_user(self):
+        return (self>>10)&1
+    
+    @property
+    def system(self):
+        return (self>>11)&1
+    
+    def __iter__(self):
+        if self&1:
+            yield 'discord_employee'
+            
+        if (self>>1)&1:
+            yield 'discord_partner'
+            
+        if (self>>2)&1:
+            yield 'bug_hunter'
+            
+        if (self>>3)&1:
+            yield 'hypesquad_bravery'
+            
+        if (self>>6)&1:
+            yield 'hypesquad_bravery'
+            
+        if (self>>7)&1:
+            yield 'hypesquad_brilliance'
+            
+        if (self>>8)&1:
+            yield 'hypesquad_balance'
+            
+        if (self>>9)&1:
+            yield 'early_supporter'
+            
+        if (self>>10)&1:
+            yield 'team_user'
+
+        if (self>>11)&1:
+            yield 'system'
+            
+    def __repr__(self):
+        return f'{self.__class__.__name__}({int.__repr__(self)})'
 
 if CACHE_PRESENCE:
     def PartialUser(user_id):
@@ -35,7 +113,7 @@ if CACHE_PRESENCE:
         user.activities=[]
 
         USERS[user_id]=user
-            
+        
         return user
 
 elif CACHE_USER:
@@ -58,7 +136,7 @@ elif CACHE_USER:
         user.partial=True
 
         USERS[user_id]=user
-            
+        
         return user
 
 else:
@@ -74,7 +152,7 @@ else:
 
         user.guild_profiles={}
         user.partial=True
-            
+        
         return user
 
 class GuildProfile(object):
@@ -124,7 +202,7 @@ class GuildProfile(object):
         roles.sort()
 
         boosts_since=data.get('premium_since',None)
-        if boosts_since is not None:
+        if (boosts_since is not None):
             boosts_since=parse_time(boosts_since)
         self.boosts_since=boosts_since
         
@@ -135,7 +213,7 @@ class GuildProfile(object):
             old['nick']=self.nick
             self.nick=nick
             
-        new_roles=[]
+        roles=[]
 
         guild_roles=guild.all_role
         for role_id in data['roles']:
@@ -144,13 +222,12 @@ class GuildProfile(object):
                 role=guild_roles[role_id]
             except KeyError:
                 continue
-            new_roles.append(role)
+            roles.append(role)
             
-        new_roles.sort()
-        role_difference=listdifference(self.roles,new_roles)
-        if role_difference[0] or role_difference[1]:
-            old['roles']=role_difference
-            self.roles[:]=new_roles
+        roles.sort()
+        if self.roles!=roles:
+            old['roles']=self.roles
+            self.roles=roles
         
         boosts_since=data.get('premium_since',None)
         if boosts_since is not None:


### PR DESCRIPTION
Changes:
- `InviteTargetType` moved to `invite.py`.
- `MessageType` moved to `message.py`.
- `MessageFlag` moved to `message.py`.
- `UserFlag` moved to `user.py`.
- `EventDescriptor.default_event` moved out as `DEFAULT_EVENT`.
- `parse_oauth2_redirect_url` moved to `oauth2.py`.
- `MessageActivity` renamed to `MessageActivityType` and moved to `message.py`.
- `_urlcutter` renamed to `urlcutter` and move to `others.py`.
- No more `listdifference` return is passed to edit events.
- `Emoji.roles` is now `set` and by default `None` (from list every time).
- `listdifference` accepts `None` and `set` of sortable as well.
- `client.events.emoji_edit` is separated to 3 different events, which are called for each change: `emoji_create`, `emoji_delete` and `emoji_edit`.
- Implement `MessageActivity` to store message activity data.
- `Message.activity` is now type `MessageActivity` (the new one) or `None`, remove `Message.activity_party_id`.

Fixes:
- `Client.emoji_edit` removed roles from the emoji by default.
- `ContentParser` did not pass parsed objects to results, if mode was set.'

News:
- `PermOW` objects are sortable.
- Add second ratelimit group for deleting messages (not used yet).
- Add emoji conversion to prettyprinters.
- Add `Attachment.created_at`.
- Add `Attachment.__repr__`.
