### PR TITLE
Added Slash Extension Handler to docs/examples

### DIFF
--- a/docs/examples/e12_slash_eh/main.py
+++ b/docs/examples/e12_slash_eh/main.py
@@ -1,0 +1,52 @@
+from hata import Client, Guild
+from hata.ext.slash import setup_ext_slash
+
+# Setting up the Client.
+#
+# If you are unsure what is happening here, I recommend going back to e10_slash_commands
+TOKEN = ''
+
+Sakuya = Client(TOKEN)
+
+# This is another way to setup the slash extension.
+# use_default_exception_handler allows us to disable the extension handler Hata comes with, and use our own.
+# But, Hata does allow multiple extension handlers, so if you want to keep the default, you can leave it as True.
+slash = setup_ext_slash(Sakuya, use_default_exception_handler=False)
+
+MY_GUILD = Guild.precreate(12345)
+
+@Sakuya.interactions(guild=MY_GUILD)
+async def test(event):
+    """
+    Simple command, this is just used to test a error handler.
+    """
+    raise TypeError()
+
+@slash.error
+async def slash_error(client, interaction_event, command, exception):
+    """
+    Setting up a basic error handler
+    When a slash command has an error, it'll go back to the Error Handler.
+
+    It'll give:
+        client              :   Client                                          | Client
+        interaction_event   :   InteractionEvent                                | Event
+        command             :   SlasherApplicationCommand, ComponentCommand     | The command that was invoked
+        exception           :   BaseException                                   | The exception that was raised
+
+    This should return a boolean
+    """
+    handled = False
+    if isinstance(exception, TypeError):
+        # Telling the user the command raised an exception
+        await client.interaction_response_message_create(interaction_event, "This command raised TypeError!")
+        # This error was handled
+        handled = True
+
+    # Returning if it handled the error or not.
+    #
+    # If this returns false, Hata will try other error handlers
+    # If the error isn't handled, it won't respond to the user and output the error in the terminal.
+    return handled
+
+Sakuya.start()

--- a/docs/examples/readme.md
+++ b/docs/examples/readme.md
@@ -18,6 +18,7 @@ Examples should be completed in order, as you might miss some notes from previou
  9 => Loops: Using cycling tasks.
 10 => Slash commands: Demonstrates a few usages of Hatas slash extension.
 11 => Basic voice: Basic usage of voice clients.
+12 => Slash exception handler: Example of how to create a slash error handler.
 ```
 
 ## Questions


### PR DESCRIPTION
This PR adds a slash extension handler to examples. I wanted to add this because I did not see this reference in the docs and, it would be easier to understand as an example. Please excuse any information if it is incorrect, I mainly assumed by looking at the technical docs and the source code.