### PR TITLE
Allow filenames with extension for hata.main.Command

### DIFF
--- a/hata/main/command.py
+++ b/hata/main/command.py
@@ -45,6 +45,8 @@ class Command(RichAttributeErrorBaseType):
         description : `str`
             The command's description.
         """
+        if file_name.endswith('.py'):
+            filename = filename[:-3]
         if (alters is not None):
             if alters:
                 alters = frozenset(alters)

--- a/hata/main/command.py
+++ b/hata/main/command.py
@@ -46,7 +46,8 @@ class Command(RichAttributeErrorBaseType):
             The command's description.
         """
         if file_name.endswith('.py'):
-            filename = filename[:-3]
+            file_name = file_name[:-3]
+        
         if (alters is not None):
             if alters:
                 alters = frozenset(alters)


### PR DESCRIPTION
Allows 

```py3
Command(
    "some_folder",
    "app_entry.py", ...
)
```

*This is an opinionated PR*