### PR TITLE
[Feature Req] Add hata cli entry point

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -128,4 +128,9 @@ setup(
             'cchardet>=2.0',
         ],
     },
+    entry_points = {
+        'console_scripts': [
+            'hata = hata.__main__:__main__'
+        ]
+    },
 )


### PR DESCRIPTION
# About
This allows users to do
`hata i` instead of `python -m hata i`

# Why not
I believe this was missing from hata for the same reasons as python/cpython#69341
to indicate what version of hata and python is being invoked, although my argument is that
hata is not as dependent on the the python version hence in 99% of the cases it wouldn't lead to usage 
which is seriously breaking (exception of `hata i` command)

# Why
1. I have ran the commands atleast a hundred times, I can affirm that the `python -m` parts gets on my nerves
2. It is standard practice to use a virtual environment so, this actually doesn't affect venv users, like me, at all.


<sub>The code follows the code style ofcourse</sub>