### PR TITLE
update readme/setup.py: python <3.13 because of audioop

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ And you are good to go! Hata has native pypy support as well if you need some mo
 
 #### Requirements
 
-- Python >= 3.6, < 3.13
+- Python >= 3.6, < 3.12
 - [chardet](https://pypi.python.org/pypi/chardet) / [cchardet](https://pypi.org/project/cchardet/)
 
 #### Optional

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ And you are good to go! Hata has native pypy support as well if you need some mo
 
 #### Requirements
 
-- Python >= 3.6
+- Python >= 3.6, < 3.13
 - [chardet](https://pypi.python.org/pypi/chardet) / [cchardet](https://pypi.org/project/cchardet/)
 
 #### Optional

--- a/setup.py
+++ b/setup.py
@@ -300,7 +300,7 @@ setup(
             'libopus-0.x86.dll',
         ],
     },
-    python_requires = '>=3.6',
+    python_requires = '>=3.6,<3.13',
     install_requires = [
         'scarletio>=1.0.89',
         'chardet>=2.0',

--- a/setup.py
+++ b/setup.py
@@ -300,7 +300,7 @@ setup(
             'libopus-0.x86.dll',
         ],
     },
-    python_requires = '>=3.6,<3.13',
+    python_requires = '>=3.6,<3.12',
     install_requires = [
         'scarletio>=1.0.89',
         'chardet>=2.0',


### PR DESCRIPTION
`audioop` got removed in Python 3.13, so `import hata` fails on 3.13;
on 3.12, seems to, at least, import fine
