### PR TITLE
prevent `SyntaxWarning` on character escapes

### DIFF
--- a/hata/discord/emoji/parsing/tests/test__parse_all_emojis.py
+++ b/hata/discord/emoji/parsing/tests/test__parse_all_emojis.py
@@ -94,7 +94,7 @@ def test__parse_all_emojis__coloned_builtin_name__2():
     emoji_1 = BUILTIN_EMOJIS['heart']
     emoji_2 = BUILTIN_EMOJIS['leg']
     
-    text = f'\:{emoji_1.name}::{emoji_2.name}:'
+    text = fr'\:{emoji_1.name}::{emoji_2.name}:'
     
     parsed_emojis = parse_all_emojis(text)
     vampytest.assert_eq({emoji_2}, parsed_emojis)
@@ -109,7 +109,7 @@ def test__parse_all_emojis__coloned_builtin_name__3():
     emoji_1 = BUILTIN_EMOJIS['heart']
     emoji_2 = BUILTIN_EMOJIS['leg']
     
-    text = f':{emoji_1.name}\::{emoji_2.name}:'
+    text = fr':{emoji_1.name}\::{emoji_2.name}:'
     
     parsed_emojis = parse_all_emojis(text)
     vampytest.assert_eq({emoji_2}, parsed_emojis)
@@ -124,7 +124,7 @@ def test__parse_all_emojis__coloned_builtin_name__4():
     emoji_1 = BUILTIN_EMOJIS['heart']
     emoji_2 = BUILTIN_EMOJIS['leg']
     
-    text = f':{emoji_1.name}:\:{emoji_2.name}:'
+    text = fr':{emoji_1.name}:\:{emoji_2.name}:'
     
     parsed_emojis = parse_all_emojis(text)
     vampytest.assert_eq({emoji_1}, parsed_emojis)

--- a/hata/discord/emoji/parsing/tests/test__parse_all_emojis.py
+++ b/hata/discord/emoji/parsing/tests/test__parse_all_emojis.py
@@ -94,7 +94,7 @@ def test__parse_all_emojis__coloned_builtin_name__2():
     emoji_1 = BUILTIN_EMOJIS['heart']
     emoji_2 = BUILTIN_EMOJIS['leg']
     
-    text = fr'\:{emoji_1.name}::{emoji_2.name}:'
+    text = f'\\:{emoji_1.name}::{emoji_2.name}:'
     
     parsed_emojis = parse_all_emojis(text)
     vampytest.assert_eq({emoji_2}, parsed_emojis)
@@ -109,7 +109,7 @@ def test__parse_all_emojis__coloned_builtin_name__3():
     emoji_1 = BUILTIN_EMOJIS['heart']
     emoji_2 = BUILTIN_EMOJIS['leg']
     
-    text = fr':{emoji_1.name}\::{emoji_2.name}:'
+    text = f':{emoji_1.name}\\::{emoji_2.name}:'
     
     parsed_emojis = parse_all_emojis(text)
     vampytest.assert_eq({emoji_2}, parsed_emojis)
@@ -124,7 +124,7 @@ def test__parse_all_emojis__coloned_builtin_name__4():
     emoji_1 = BUILTIN_EMOJIS['heart']
     emoji_2 = BUILTIN_EMOJIS['leg']
     
-    text = fr':{emoji_1.name}:\:{emoji_2.name}:'
+    text = f':{emoji_1.name}:\\:{emoji_2.name}:'
     
     parsed_emojis = parse_all_emojis(text)
     vampytest.assert_eq({emoji_1}, parsed_emojis)

--- a/hata/discord/tests/test__escape_markdown.py
+++ b/hata/discord/tests/test__escape_markdown.py
@@ -7,7 +7,7 @@ def iter_options():
     yield None, None
     yield '', ''
     yield 'aya', 'aya'
-    yield 'aya_aya', r'aya\_aya'
+    yield 'aya_aya', 'aya\\_aya'
     yield '\\', '\\\\'
     yield '_', '\\_'
     yield '*', '\\*'

--- a/hata/discord/tests/test__escape_markdown.py
+++ b/hata/discord/tests/test__escape_markdown.py
@@ -7,8 +7,8 @@ def iter_options():
     yield None, None
     yield '', ''
     yield 'aya', 'aya'
-    yield 'aya_aya', 'aya\_aya'
-    yield '\\', '\\\\' 
+    yield 'aya_aya', r'aya\_aya'
+    yield '\\', '\\\\'
     yield '_', '\\_'
     yield '*', '\\*'
     yield '|', '\\|'

--- a/hata/ext/patchouli/builder_html_extended.py
+++ b/hata/ext/patchouli/builder_html_extended.py
@@ -980,8 +980,8 @@ class AttributeSection:
         
         return Structure(title, prefixed_title, children)
 
-PARAMETER_NAME_RP = re.compile('(\*{0,2}[a-zA-Z_]+[a-zA-Z_0-9]*)(?: *\: *(.+)?)?')
-PARAMETER_OPTIONALITY_RP = re.compile('(.*?)(?:,? *([Oo]ptional)(?:,? *\(?([Kk]eyword [Oo]nly)\)?)?)?')
+PARAMETER_NAME_RP = re.compile(r'(\*{0,2}[a-zA-Z_]+[a-zA-Z_0-9]*)(?: *\: *(.+)?)?')
+PARAMETER_OPTIONALITY_RP = re.compile(r'(.*?)(?:,? *([Oo]ptional)(?:,? *\(?([Kk]eyword [Oo]nly)\)?)?)?')
 PARAMETER_DEFAULT_START_RP = re.compile('(.*?) *= *(.*?)')
 
 PARAMETER_SHIFT_NAME = 0

--- a/hata/ext/patchouli/builder_html_extended.py
+++ b/hata/ext/patchouli/builder_html_extended.py
@@ -980,8 +980,8 @@ class AttributeSection:
         
         return Structure(title, prefixed_title, children)
 
-PARAMETER_NAME_RP = re.compile(r'(\*{0,2}[a-zA-Z_]+[a-zA-Z_0-9]*)(?: *\: *(.+)?)?')
-PARAMETER_OPTIONALITY_RP = re.compile(r'(.*?)(?:,? *([Oo]ptional)(?:,? *\(?([Kk]eyword [Oo]nly)\)?)?)?')
+PARAMETER_NAME_RP = re.compile('(\\*{0,2}[a-zA-Z_]+[a-zA-Z_0-9]*)(?: *\\: *(.+)?)?')
+PARAMETER_OPTIONALITY_RP = re.compile('(.*?)(?:,? *([Oo]ptional)(?:,? *\\(?([Kk]eyword [Oo]nly)\\)?)?)?')
 PARAMETER_DEFAULT_START_RP = re.compile('(.*?) *= *(.*?)')
 
 PARAMETER_SHIFT_NAME = 0

--- a/hata/ext/patchouli/builder_text.py
+++ b/hata/ext/patchouli/builder_text.py
@@ -249,7 +249,7 @@ def graved_to_escaped_words(graved):
             else:
                 add_space_before = False
             
-            local_words = element.replace('_', r'\_').split(' ')
+            local_words = element.replace('_', '\\_').split(' ')
             if (not add_space_before) and words:
                 words[-1] = words[-1] + local_words.pop(0)
             

--- a/hata/ext/patchouli/builder_text.py
+++ b/hata/ext/patchouli/builder_text.py
@@ -10,7 +10,7 @@ from .graver import (
 
 INDENT_SIZE_DEFAULT = 4
 
-DO_NOT_PREVIEW_RP = re.compile('this [a-z]+ is a [a-z]+\.?', re.I)
+DO_NOT_PREVIEW_RP = re.compile(r'this [a-z]+ is a [a-z]+\.?', re.I)
 
 SPACE_CHAR_DEFAULT = ' '
 SPACE_CHAR_UNICODE = (b'\xe2\xa0\x80').decode()
@@ -249,7 +249,7 @@ def graved_to_escaped_words(graved):
             else:
                 add_space_before = False
             
-            local_words = element.replace('_', '\_').split(' ')
+            local_words = element.replace('_', r'\_').split(' ')
             if (not add_space_before) and words:
                 words[-1] = words[-1] + local_words.pop(0)
             

--- a/hata/ext/patchouli/builder_text.py
+++ b/hata/ext/patchouli/builder_text.py
@@ -10,7 +10,7 @@ from .graver import (
 
 INDENT_SIZE_DEFAULT = 4
 
-DO_NOT_PREVIEW_RP = re.compile(r'this [a-z]+ is a [a-z]+\.?', re.I)
+DO_NOT_PREVIEW_RP = re.compile('this [a-z]+ is a [a-z]+\\.?', re.I)
 
 SPACE_CHAR_DEFAULT = ' '
 SPACE_CHAR_UNICODE = (b'\xe2\xa0\x80').decode()

--- a/hata/ext/patchouli/parser.py
+++ b/hata/ext/patchouli/parser.py
@@ -9,17 +9,17 @@ from .graver import (
 
 
 SECTION_NAME_RP = re.compile('(?:[A-Z][a-z]*)(?: [A-Z][a-z]*)*')
-SECTION_UNDERLINE_RP = re.compile('[\-]+')
-TABLE_BORDER_PATTERN = '\+(?:[\-=]+\+)+'
-TABLE_TEXT_PATTERN = '\|(?:[^\|]+\|)+'
+SECTION_UNDERLINE_RP = re.compile(r'[\-]+')
+TABLE_BORDER_PATTERN = r'\+(?:[\-=]+\+)+'
+TABLE_TEXT_PATTERN = r'\|(?:[^\|]+\|)+'
 TABLE_BORDER_RP = re.compile(TABLE_BORDER_PATTERN)
 TABLE_TEXT_RP = re.compile(TABLE_TEXT_PATTERN)
 TABLE_ANY_RP = re.compile(f'{TABLE_BORDER_PATTERN}|{TABLE_TEXT_PATTERN}')
-TABLE_TEXT_SPLITTER = re.compile('(?:\| )?(.*?) \|')
-LISTING_HEAD_LINE_RP = re.compile('[\-]+[ \t]*(.*)')
+TABLE_TEXT_SPLITTER = re.compile(r'(?:\| )?(.*?) \|')
+LISTING_HEAD_LINE_RP = re.compile(r'[\-]+[ \t]*(.*)')
 
 ATTRIBUTE_SECTION_NAME_RP = re.compile('.*?attributes?', re.I)
-ATTRIBUTE_NAME_RP = re.compile('([A-Za-z_][0-9A-Za-z_]*) *([\:\(]) *')
+ATTRIBUTE_NAME_RP = re.compile(r'([A-Za-z_][0-9A-Za-z_]*) *([\:\(]) *')
 
 del TABLE_BORDER_PATTERN
 del TABLE_TEXT_PATTERN

--- a/hata/ext/patchouli/parser.py
+++ b/hata/ext/patchouli/parser.py
@@ -9,17 +9,17 @@ from .graver import (
 
 
 SECTION_NAME_RP = re.compile('(?:[A-Z][a-z]*)(?: [A-Z][a-z]*)*')
-SECTION_UNDERLINE_RP = re.compile(r'[\-]+')
+SECTION_UNDERLINE_RP = re.compile('[\\-]+')
 TABLE_BORDER_PATTERN = r'\+(?:[\-=]+\+)+'
 TABLE_TEXT_PATTERN = r'\|(?:[^\|]+\|)+'
 TABLE_BORDER_RP = re.compile(TABLE_BORDER_PATTERN)
 TABLE_TEXT_RP = re.compile(TABLE_TEXT_PATTERN)
 TABLE_ANY_RP = re.compile(f'{TABLE_BORDER_PATTERN}|{TABLE_TEXT_PATTERN}')
-TABLE_TEXT_SPLITTER = re.compile(r'(?:\| )?(.*?) \|')
-LISTING_HEAD_LINE_RP = re.compile(r'[\-]+[ \t]*(.*)')
+TABLE_TEXT_SPLITTER = re.compile('(?:\\| )?(.*?) \\|')
+LISTING_HEAD_LINE_RP = re.compile('[\\-]+[ \t]*(.*)')
 
 ATTRIBUTE_SECTION_NAME_RP = re.compile('.*?attributes?', re.I)
-ATTRIBUTE_NAME_RP = re.compile(r'([A-Za-z_][0-9A-Za-z_]*) *([\:\(]) *')
+ATTRIBUTE_NAME_RP = re.compile('([A-Za-z_][0-9A-Za-z_]*) *([\\:\\(]) *')
 
 del TABLE_BORDER_PATTERN
 del TABLE_TEXT_PATTERN

--- a/hata/main/commands/default/scaffold/layouts/package/readme_rendering.py
+++ b/hata/main/commands/default/scaffold/layouts/package/readme_rendering.py
@@ -609,7 +609,7 @@ def render_readme_section_structure_plugins_init(into, project_name):
     into.append('### ./')
     into.append(project_name)
     into.append(
-        '/plugins/\_\_init\_\_.py\n'
+        r'/plugins/\_\_init\_\_.py\n'
         '\n'
         'This `__init__.py` is required for cross-plugin imports.\n'
         '\n'

--- a/hata/main/commands/default/scaffold/layouts/package/readme_rendering.py
+++ b/hata/main/commands/default/scaffold/layouts/package/readme_rendering.py
@@ -609,7 +609,7 @@ def render_readme_section_structure_plugins_init(into, project_name):
     into.append('### ./')
     into.append(project_name)
     into.append(
-        r'/plugins/\_\_init\_\_.py\n'
+        '/plugins/\\_\\_init\\_\\_.py\n'
         '\n'
         'This `__init__.py` is required for cross-plugin imports.\n'
         '\n'


### PR DESCRIPTION
most fixes involve `r`- (raw) strings, but one had to use `\\` because it also contained a proper escape, `\n`, and doing `r"..." "\n"` felt like too much of a hack

`r"..."` is picked over `\\` for consistency with the convention of using `r"..."` with `re`